### PR TITLE
fix: `std` features were enabled by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "az"
@@ -16,9 +16,9 @@ checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "cfg-if"
@@ -34,9 +34,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "fixed"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc715d38bea7b5bf487fcd79bcf8c209f0b58014f3018a7a19c2b855f472048"
+checksum = "85c6e0b89bf864acd20590dbdbad56f69aeb898abfc9443008fd7bd48b2cc85a"
 dependencies = [
  "az",
  "bytemuck",
@@ -67,15 +67,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -83,8 +83,7 @@ dependencies = [
 [[package]]
 name = "piddiy"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f760a3718d2181ac4b197b74318babde6848883e473bcbfc39f7f7e3f520a92a"
+source = "git+https://github.com/LechevSpace/piddiy?branch=fix/no_std-num-trait-for-float-numbers#6cb2120e533ce99e7b5bcc26472fe0db8350b8ca"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,20 @@ repository = "https://github.com/AeroRust/free-flight-stabilization"
 
 rust-version = "1.71"
 
+[features]
+default = []
+std = ["num-traits/std", "piddiy/std", "fixed/std"]
+
 [dependencies]
-num-traits = "0.2.18"
+num-traits = { version = "0.2", default-features = false }
 piddiy = "0.1.1"
 
 [dev-dependencies]
-fixed = { version = "1.27.0", features = ["num-traits"] }
-libc = "0.2.154"
+fixed = { version = "1.28", features = ["num-traits"] }
+libc = { version = "0.2", default-features = false }
+
+[patch.crates-io]
+piddiy = { version = "0.1.1", git = "https://github.com/LechevSpace/piddiy", branch = "fix/no_std-num-trait-for-float-numbers" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! version 1.3, an Arduino-based flight controller software. These functions
 //! are used to stabilize unmanned aerial vehicles (UAVs).
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
Fixes https://github.com/AeroRust/free-flight-stabilization/issues/3
Before merging and releasing the fix:

- [ ] merge after `piddiy` PR https://github.com/sgeos/piddiy/pull/1 was merged and Released
- [ ] Remove patch for `piddiy`